### PR TITLE
Update version to 0.3.6 and modify publish settings

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,4 +40,4 @@ jobs:
           # This is used for uploading release assets to github
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pnpm exec electron-builder -- --publish never --mac
+          pnpm exec electron-builder -- --publish always --mac

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aime-chat",
   "description": "A foundation for scalable desktop apps",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "keywords": [
     "electron",
     "boilerplate",
@@ -403,7 +403,8 @@
     "publish": {
       "provider": "github",
       "owner": "DarkNoah",
-      "repo": "aime-chat"
+      "repo": "aime-chat",
+      "releaseType": "release"
     }
   },
   "devEngines": {

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aime-chat",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aime-chat",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aime-chat",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "A foundation for scalable desktop apps",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
- Bump version to 0.3.6 in package.json and package-lock.json.
- Update GitHub Actions workflow to always publish builds for macOS.